### PR TITLE
replace compile with the version in  restrictedpython

### DIFF
--- a/.idea/vcs.xml
+++ b/.idea/vcs.xml
@@ -1,6 +1,0 @@
-<?xml version="1.0" encoding="UTF-8"?>
-<project version="4">
-  <component name="VcsDirectoryMappings">
-    <mapping directory="$PROJECT_DIR$" vcs="Git" />
-  </component>
-</project>

--- a/.idea/vcs.xml
+++ b/.idea/vcs.xml
@@ -1,0 +1,6 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project version="4">
+  <component name="VcsDirectoryMappings">
+    <mapping directory="$PROJECT_DIR$" vcs="Git" />
+  </component>
+</project>

--- a/pyecore/ecore.py
+++ b/pyecore/ecore.py
@@ -21,6 +21,8 @@ import inspect
 from decimal import Decimal
 from datetime import datetime
 from ordered_set import OrderedSet
+from RestrictedPython import compile_restricted
+from RestrictedPython import safe_builtins
 from .notification import ENotifer, Kind
 from .innerutils import ignored, javaTransMap, parse_date
 
@@ -708,8 +710,10 @@ class EClass(EClassifier):
     def __create_fun(self, eoperation):
         name = eoperation.normalized_name()
         namespace = {}
-        code = compile(eoperation.to_code(), "<str>", "exec")
-        exec(code, namespace)
+        # code = compile(eoperation.to_code(), "<str>", "exec")
+        # exec(code, namespace)
+        code = compile_restricted(eoperation.to_code(), '<inline>', 'exec')
+        exec(code, safe_builtins, namespace)
         setattr(self.python_class, name, namespace[name])
 
     def __compute_supertypes(self):

--- a/setup.py
+++ b/setup.py
@@ -26,7 +26,8 @@ setup(
     include_package_data=True,
     install_requires=['ordered-set',
                       'lxml',
-                      'defusedxml'],
+                      'defusedxml',
+                      'restrictedpython==4.0b6'],
     tests_require=['pytest'],
     license='BSD 3-Clause',
     classifiers=[

--- a/setup.py
+++ b/setup.py
@@ -27,7 +27,7 @@ setup(
     install_requires=['ordered-set',
                       'lxml',
                       'defusedxml',
-                      'restrictedpython==4.0b6'],
+                      'restrictedpython>=4.0b6'],
     tests_require=['pytest'],
     license='BSD 3-Clause',
     classifiers=[

--- a/tox.ini
+++ b/tox.ini
@@ -11,12 +11,15 @@ deps =
     coverage
     pytest
     setuptools
+    restrictedpython>=4.0b6
 
 [testenv:flake8]
 commands =
     flake8 pyecore setup.py
 deps =
     flake8
+    restrictedpython>=4.0b6
+       
 
 [testenv:cosmic_ray]
 commands =


### PR DESCRIPTION
@aranega 
Hi Vincent, 
  I'm not sure if this is necessary. But I run the bandit scan on pyecore and it reports two concerns. The first one is the invoke of exec and I try to put a pull here to alleviate it(althought it won't disable the warning). The second one is the urlopen which I think should be fine. 
Thanks!
-Andy 
  