### PR TITLE
Fixed #58: Small XMI issues

### DIFF
--- a/pyecore/ecore.py
+++ b/pyecore/ecore.py
@@ -264,7 +264,7 @@ class EObject(ENotifer):
             return '{0}/@{1}.{2}' \
                    .format(parent.eURIFragment(), name, str(index))
         else:
-            return '{0}/{1}'.format(parent.eURIFragment(), name)
+            return '{0}/@{1}'.format(parent.eURIFragment(), name)
 
     def eRoot(self):
         if not self.eContainer():

--- a/pyecore/resources/resource.py
+++ b/pyecore/resources/resource.py
@@ -518,7 +518,7 @@ class Resource(object):
         if id_attribute:
             etype = id_attribute.eType
             id_att_value = obj.eGet(id_attribute)
-            if id_att_value is not None:
+            if(id_att_value is not None) and (' ' not in id_att_value): #the check for ' ' prevents malformed ids to used as references
                 return (etype.to_string(id_att_value), False)
         return (obj.eURIFragment(), False)
 


### PR DESCRIPTION
Fixed #58: 
- When storing non-containment references an @ is missing before single element references.
- When using id attributes as references, it is not checked for malformed id values. E.g. a space in the id attributes value creates errors the next time the file is loaded because it seems like multiple references to be loaded (split at the spaces). However, non of the partial ids will exists.