### PR TITLE
Fix EDate serialization

### DIFF
--- a/pyecore/ecore.py
+++ b/pyecore/ecore.py
@@ -1030,7 +1030,7 @@ ENativeType = EDataType('ENativeType', object)
 EJavaObject = EDataType('EJavaObject', object)
 EDate = EDataType('EDate', datetime,
                   from_string=parse_date,
-                  to_string=lambda d: d.isoformat())
+                  to_string=lambda d: d.strftime('%Y-%m-%dT%H:%M:%S.%f%z'))
 EBigDecimal = EDataType('EBigDecimal', Decimal, from_string=Decimal)
 EByte = EDataType('EByte', bytes)
 EByteObject = EDataType('EByteObject', bytes)

--- a/pyecore/innerutils.py
+++ b/pyecore/innerutils.py
@@ -56,11 +56,11 @@ def parse_date(str_date):
     try:
         return datetime.fromisoformat(str_date)
     except Exception:
-        formats = ('%Y-%m-%dT%H:%M:%S.%f',
+        formats = ('%Y-%m-%dT%H:%M:%S.%f%z',
                    '%Y-%m-%dT%H:%M:%S.%f',
                    '%Y-%m-%dT%H:%M:%S',
                    '%Y-%m-%dT%H:%M',
-                   '%Y-%m-%d %H:%M:%S.%f',
+                   '%Y-%m-%d %H:%M:%S.%f%z',
                    '%Y-%m-%d %H:%M:%S.%f',
                    '%Y-%m-%d %H:%M:%S',
                    '%Y-%m-%d %H:%M',


### PR DESCRIPTION
This patch provides a solution to the issues with time zone information in dates. It makes the parsing and serialization of dates compatible with how EMF currently handles dates and UTC offsets.

Fixes issue #64 and #54 