### PR TITLE
Issue/xmi empty references refer to root

### DIFF
--- a/pyecore/resources/xmi.py
+++ b/pyecore/resources/xmi.py
@@ -280,16 +280,17 @@ class XMIResource(Resource):
                 else:
                     values = [value]
                 for value in values:
-                    resolved_value = self._resolve_nonhref(value)
-                    if not resolved_value:
-                        raise ValueError('EObject for {0} is unknown'
-                                         .format(value))
-                    if not hasattr(resolved_value, '_inverse_rels'):
-                        resolved_value = resolved_value.eClass
-                    if ref.many:
-                        eobject.__getattribute__(name).append(resolved_value)
-                    else:
-                        eobject.__setattr__(name, resolved_value)
+                    if(value): #BA: Skip empty references
+                        resolved_value = self._resolve_nonhref(value)
+                        if not resolved_value:
+                            raise ValueError('EObject for {0} is unknown'
+                                             .format(value))
+                        if not hasattr(resolved_value, '_inverse_rels'):
+                            resolved_value = resolved_value.eClass
+                        if ref.many:
+                            eobject.__getattribute__(name).append(resolved_value)
+                        else:
+                            eobject.__setattr__(name, resolved_value)
 
         for eobject, ref, value in opposite:
             resolved_value = self._resolve_nonhref(value)


### PR DESCRIPTION
If deleting an object that is also referred by a non-containment reference elswhere, pyecore serializes that to xmi as ref="". When loading the file again loading fails because "" seems to be resolved to the model root, which than has the wrong type for the reference (BadValueError). The fix solves the loading issue by skiping empty references.