### PR TITLE
Fix root element id not added to uuid_dict if its feature.ID is set.

### DIFF
--- a/pyecore/resources/xmi.py
+++ b/pyecore/resources/xmi.py
@@ -124,6 +124,8 @@ class XMIResource(Resource):
                     continue
                 if feature.is_attribute:
                     self._decode_eattribute_value(modelroot, feature, value)
+                    if feature.iD:
+                        self.uuid_dict[value] = modelroot
                 else:
                     erefs.append((feature, value))
         if erefs:


### PR DESCRIPTION
This PR fixes the missing root node's ID in the uuid_dict when the root node has the ID feature set.