### PR TITLE
Support deserialization of an alternative reference scheme

### DIFF
--- a/pyecore/resources/resource.py
+++ b/pyecore/resources/resource.py
@@ -484,6 +484,10 @@ class Resource(object):
                 except IndexError:
                     raise ValueError('Index in path is not the collection,'
                                      ' broken proxy?')
+                except ValueError:
+                    # If index is not numeric it may be given as a name.
+                    if index:
+                        obj = tmp_obj.select(lambda x: x.name == index )[0]
             elif key.startswith('%'):
                 key = key[1:-1]
                 obj = obj.eAnnotations.select(lambda x: x.source == key)[0]


### PR DESCRIPTION
This change adds support for an alternative serialization schema
for references in the form $container.$name if the item has an
attribute name in addition to the usual schema $container.$index.