### PR TITLE
* forced the initialization of default values of EAttributes if a cla…

### DIFF
--- a/pyecore/ecore.py
+++ b/pyecore/ecore.py
@@ -746,6 +746,14 @@ class EClass(EClassifier):
             instance.__name__ = metainstance.__name__
         else:
             def new_init(self, *args, **kwargs):
+                #first initialize default values...
+                eattrs = self.eClass.eAllAttributes()
+                for eattr in eattrs:
+                    if(eattr.defaultValueLiteral):
+                        name = eattr.name
+                        value = eattr.eType.from_string(eattr.defaultValueLiteral)
+                        setattr(self, name, value)
+                #...then copy given values
                 for name, value in kwargs.items():
                     setattr(self, name, value)
             attr_dict = {


### PR DESCRIPTION
This is a suggestion for fixing incorrectly set default values of attributes if classes are created dynamically. I do not know if the code is at the most suitable position, because I did not get the class declaration mechanism completly. Please move it if there is a better place.

Commit: forced the initialization of default values of EAttributes if a class is created with __new__. Otherwise attributes are not set to default values when using <ClassName>() for Classes dynamically defined.