### PR TITLE
Fix non-serializable EDataType instanceClassName

### DIFF
--- a/pyecore/ecore.py
+++ b/pyecore/ecore.py
@@ -483,7 +483,7 @@ class EDataType(EClassifier):
         if instanceClassName:
             self.instanceClassName = instanceClassName
         else:
-            self._instanceClassName = None
+            self.instanceClassName_ = None
         if from_string:
             self.from_string = from_string
         if to_string:
@@ -511,11 +511,11 @@ class EDataType(EClassifier):
 
     @property
     def instanceClassName(self):
-        return self._instanceClassName
+        return self.instanceClassName_
 
     @instanceClassName.setter
     def instanceClassName(self, name):
-        self._instanceClassName = name
+        self.instanceClassName_ = name
         default_type = (object, True, None)
         type_, type_as_factory, default = self.transmap.get(name, default_type)
         self.eType = type_


### PR DESCRIPTION
I've found some issue with custom EDataType and serializing it.

Code:
```
from pyecore.ecore import *
from pyecore.resources import ResourceSet, URI

testDT = EDataType('TestDT', instanceClassName='int')

my_ecore_schema = EPackage('my_ecore', nsURI='http://myecore/1.0', nsPrefix='myecore')
my_ecore_schema.eClassifiers.append(testDT)

rset = ResourceSet()
resource = rset.create_resource(URI('tmp.ecore'))
resource.append(my_ecore_schema)
resource.save()
```

Before patch content of tmp.ecore:
```
<?xml version='1.0' encoding='UTF-8'?>
<ecore:EPackage xmlns:xmi="http://www.omg.org/XMI" xmlns:ecore="http://www.eclipse.org/emf/2002/Ecore" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" nsURI="http://myecore/1.0" nsPrefix="myecore" name="my_ecore" xmi:version="2.0">
  <eClassifiers xsi:type="ecore:EDataType" name="TestDT"/>
</ecore:EPackage>
```

After patch:
```
<?xml version='1.0' encoding='UTF-8'?>
<ecore:EPackage xmlns:xmi="http://www.omg.org/XMI" xmlns:ecore="http://www.eclipse.org/emf/2002/Ecore" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" nsURI="http://myecore/1.0" name="my_ecore" nsPrefix="myecore" xmi:version="2.0">
  <eClassifiers xsi:type="ecore:EDataType" name="TestDT" instanceClassName="int"/>
</ecore:EPackage>
```