### PR TITLE
Fix issue with apply_relative_from_me() for HttpURI

### DIFF
--- a/pyecore/resources/resource.py
+++ b/pyecore/resources/resource.py
@@ -214,7 +214,8 @@ class HttpURI(URI):
         raise NotImplementedError('Cannot create an outstream for HttpURI')
 
     def apply_relative_from_me(self, relative_path):
-        return self.plain
+        # currently no relative path is calculated for HttpURI.
+        return relative_path 
 
 
 # class StdioURI(URI):


### PR DESCRIPTION
If a resource is loaded from a HttpURI and that resource has a crossreference to another resource using an HttpURI, the wrong uri is given back in apply_relative_for_me(), causing the referenced resource not being loaded.

This fixes this problem.