### PR TITLE
Fix for None value returned by EReference.container

### DIFF
--- a/pyecore/ecore.py
+++ b/pyecore/ecore.py
@@ -784,7 +784,7 @@ class EReference(EStructuralFeature):
 
     @property
     def container(self):
-        return self._eopposite and self._eopposite.containment
+        return None != self._eopposite and self._eopposite.containment
 
     @property
     def is_reference(self):


### PR DESCRIPTION
This fixes problems I had accessing the container property of EReferences. In some cases it returned None instead of a bool value. In debugging it looked like it will evaluate the second part of the AND although the first statement is False, which results in an exception and finally a None return value. I do not understand why this happens, but this change fixed my issues.