### PR TITLE
Bugfix: Fixed incorrect placement of reverse=True in sorted() for tuple conversion

### DIFF
--- a/pyecore/ecore.py
+++ b/pyecore/ecore.py
@@ -828,10 +828,11 @@ class EClass(EClassifier):
                 instance.python_class = type(name, super_types, attr_dict)
             except Exception:
                 try:
-                    super_types = tuple(sorted(super_types,
-                                         key=lambda x: len(x.eClass
-                                                            .eAllSuperTypes())),
-                                         reverse=True)
+                    super_types = tuple(
+                        sorted(super_types,
+                               key=lambda x: len(x.eClass.eAllSuperTypes()),
+                               reverse=True)
+                    )
                     instance.python_class = type(name,
                                                  super_types,
                                                  attr_dict)


### PR DESCRIPTION
Moved reverse=True to the sorted() function to avoid TypeError caused by its incorrect application to tuple(). Ensured proper descending order of sorted elements before tuple conversion. Reformatted indents to increase the readability of argument placements.